### PR TITLE
Uses Ember get instead of POJO getter.

### DIFF
--- a/addon/helpers/invoke.js
+++ b/addon/helpers/invoke.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { helper } from '@ember/component/helper';
 
 export function invokeFunction([context, method, ...rest]) {
@@ -5,7 +6,7 @@ export function invokeFunction([context, method, ...rest]) {
     throw new Error(`Method '${method}' is not defined or cannot be invoked.`);
   }
 
-  return context[method].apply(context, rest);
+  return Ember.get(context,method).apply(context, rest);
 }
 
 export default helper(invokeFunction);


### PR DESCRIPTION
This allows you use to leverage services or other methods that won't be in the POJO context of the app.